### PR TITLE
Explain the case where you want to exclude an IP from mynetworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
-## 2020-08-6
+## 2020-08-08
+
+- Changed: Modified the comments on the mailad.conf file about the exclusion of one or more IP form the net segment
+
+## 2020-08-06
 
 - Changed: Improved SSL/TLS security on dovecot & postfix
 - Changed: Optimized some scripts related to SSL and testing

--- a/mailad.conf
+++ b/mailad.conf
@@ -55,13 +55,28 @@ MESSAGESIZE=2
 # don't need to put them here
 #
 # Any PC with an IP in this range can send email without password auth
-# even to the outside world, this is useful for DMZ status mails
-# collection for example
+# and without restrictions, even to the outside world, this is useful
+# for DMZ status mails from other servers via plain SMTP, or to receive
+# emails from the mail gateway
 # 
-# NEVER put the user's network on here
+# NEVER put the user's network here, NEVER!
 #
-# Warning: use "quotes" around it and separe multiple entries with
-# a comma, like this "10.0.0.0/24,172.16.0.0/27" 
+# Use "quotes" around it and separe multiple entries with a comma and
+# space, like this "10.0.0.0/24, 172.16.0.0/27"
+#
+# WARINING!: If you have a webmail (roundcube/rainloop/horde/etc)
+# be aware that if the IP of the the webmail falls under the net
+# segment declared here it will bypass all resctrictions, ALL
+# RESTRICTIONS!
+#
+# To exclude one or more IPs from a subnet you can use the '!' operator
+# for example to exclude the IP 192.168.1.5 from the 192.168.1.0/27
+# range you can put it like this:
+#
+# "!192.168.1.5, 192.168.1.0/27"
+#
+# You can use more than one IP, but exclusions must be declared before
+# the network segment, not before
 #
 MYNETWORK="10.42.0.0/29"
 
@@ -75,6 +90,10 @@ MYNETWORK="10.42.0.0/29"
 # 
 # If your deliver the mails directly to the destination servers
 # leave it blank
+#
+# Proxmox Mail Gateway note: remember that PMG uses port 26 for the
+# outgoing mails, to append ":26" to the IP or hostname
+#
 RELAY=
 
 ### Mail user owner


### PR DESCRIPTION
Some times you need to exclude an IP in the mynetworks segment of postfix, as this IP has no access control. In the case you declared a whole DMZ subnet and you have a webmail in there you need to exclude the webmail's IP or some restrictions will not be applied
 