### PR TITLE
Bug Fix: delayed av-checking script is failing

### DIFF
--- a/var/clamav-related/activate_clamav_on_alive.sh
+++ b/var/clamav-related/activate_clamav_on_alive.sh
@@ -21,7 +21,7 @@ fi
 
 # test if clamav-daemon is runnig already, it will run only when freshclam manages to get a full db download
 R=`systemctl show -p SubState --value clamav-daemon`
-if [ "$R" == "runnig" ] ; then
+if [ "$R" == "running" ] ; then
     # it's alive!, doing our thing
 
     # configure AV filtering on amavis if not already active


### PR DESCRIPTION
Delayed AV-checking script is failing, a typo spoiled a test and it will never trigger the AV filter activation, spamming the mail admin with av not being activated every our...

My bad.