### PR TITLE
Ban (Reject) messages with no subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-09-11
+
+- Add: Subject-less emails are rejected by default, thanks to Danny Paula (Telegram: @danny920825)
+
 ## 2020-09-01
 
 - Fixed: Delayed activation for the AV in amavis failed as the script has a wrong check in an if statement, a typo from my side (that generates an annoying hourly mail and never activated the AV checking)

--- a/Features.md
+++ b/Features.md
@@ -35,6 +35,7 @@ If you are using it under a heavier load, please share with me the statistics an
 - Built using established best security practices.
 - We will keep it updated against emerging threats.
 - Fix for a recent spammer trick: forgery of the From/Return-Path to make the users think the mails are legitimate when they are not.
+- Ban (reject) of subject-less emails, a common spammer trick
 
 Backed up by the collective knowledge of the [SysAdminsdeCuba](https://t.me/sysadmincuba) SysAdmins community.
 

--- a/var/postfix/rules/header_checks
+++ b/var/postfix/rules/header_checks
@@ -13,4 +13,4 @@
 /^((Envelope\-)?From|Return\-Path):\s*[^<]*<[^@]+@[^@>]+>[^<]*<[^@]+@[^@>]+>/     REJECT No double address in the From or Return-path allowed
 
 # Ban subject less emails
-/^Subject:\s$/		REJECT No se permiten mensajes sin asunto / No subject-less email please
+/^Subject:\s*$/		REJECT No se permiten mensajes sin asunto / No subject-less email please

--- a/var/postfix/rules/header_checks
+++ b/var/postfix/rules/header_checks
@@ -7,7 +7,10 @@
 # analyze it 
 
 # Expresion				        Action  No  Reason
-/^Subject: .* [P|p]uta .*/		REJECT (#1) No se permiten Mala palabras
+/^Subject:\s.* [Pp]uta .*/		REJECT (#1) No se permiten Mala palabras
 
-# Evitar truco de doble source que confunde al user
+# Ban sender/return forgery
 /^((Envelope\-)?From|Return\-Path):\s*[^<]*<[^@]+@[^@>]+>[^<]*<[^@]+@[^@>]+>/     REJECT No double address in the From or Return-path allowed
+
+# Ban subject less emails
+/^Subject:\s$/		REJECT No se permiten mensajes sin asunto / No subject-less email please


### PR DESCRIPTION
Subject less emails are a bad practice and a common spammer trick.

This will disable them 