### PR TITLE
Maildir removal as optional feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-09-15
+
+- Changed: Made the maildir removal optional and disabled by default
+
 ## 2020-09-14
 
 - Added: new feature: we don't erase the user's maildir up on removal from the AD, we will keep it and warn the sysadmin to take actions with them, after a year the maildir is automatically erased

--- a/Features.md
+++ b/Features.md
@@ -60,6 +60,14 @@ Here we play a trick:
 - Maildirs for deleted users between 10 to 11.999 months will be warned about imminent removal.
 - Maildirs for deleted users older than 365 days (1 year) will be removed and you will receive the removal notification.
 
+Well no quite, the first time you will not get the maildirs removed, you will be notified about the maildirs that _will be_ erased and the way to activate that feature.
+
+To activate that option you need to set the option `MAILDIRREMOVAL="yes"` in the config file `/etc/mailad/mailad.conf` _(you don't have that option? it's time to upgrade... see [Painless upgrades](Features.md#painless-upgrades))_ and then reprovision the server with this command:
+
+``` sh
+make force-provision
+```
+
 We think that a year is time enough to recover something from that mailbox; also that date as a legal implication: in some scenarios you are required to maintain a copy of all users digital footprint for at least one year.
 
 Here you can see an notification sample from the first implementation of this feature:

--- a/mailad.conf
+++ b/mailad.conf
@@ -305,9 +305,23 @@ PROXY_USER=""
 PROXY_PASS=""
 
 #############################################################################
+#                       AUTOMATIC MAILDIR REMOVAL
+#############################################################################
+
+# Please see Features.md file for details.
+#
+# This variable controls if maildirs with no user asociated in the AD will be
+# removed for good or peserved after one year of user deletion
+#
+# As he removal is final it will be disabled by default, it's your duty to
+# decide what to do. You will be notified once month about this 
+#
+MAILDIRREMOVAL="no"
+
+#############################################################################
 #                VERSION CONTROL: DO NOT TOUCH
 #############################################################################
 
 # DO NOT CHANGE THE FOLLOWING VARIABLE
-CONFVER=6
+CONFVER=7
 

--- a/scripts/check_maildirs.sh
+++ b/scripts/check_maildirs.sh
@@ -91,7 +91,6 @@ for md in `ls ${VMAILSTORAGE} | xargs` ; do
                     echo  "          /etc/mailad/mailad.conf file setting the option"  >> ${erasedlist}
                     echo  "          MAILDIRREMOVAL='yes', remember to make a 'make force-provision'"  >> ${erasedlist}
                     echo  "          in your mailad local repo folder to apply the change."  >> ${erasedlist}
-                    echo  " " >> ${erasedlist}
                 else
                     # delete it for good
                     rm -rdf "${maildir}"

--- a/scripts/check_maildirs.sh
+++ b/scripts/check_maildirs.sh
@@ -80,8 +80,22 @@ for md in `ls ${VMAILSTORAGE} | xargs` ; do
             # older than 75 % of a year
             if [ ${days} -gt 365 ] ; then
                 # delete!
-                rm -rdf "$maildir"
                 printf "%s months/(%s days)\t%s\t%s\n" "${months}" "${days}" "${size}" "${maildir}" >> ${erasedlist}
+
+                # check for real deletion
+                if [ "$MAILDIRREMOVAL" == "" -o "$MAILDIRREMOVAL" == "no" -o "$MAILDIRREMOVAL" == "No" ] ; then
+                    # no deletion, warn abut the option
+                    echo  " " >> ${erasedlist}
+                    echo  "WARNING!: There was no deletion at all, as it's a dangerous action it" >> ${erasedlist}
+                    echo  "          cames disbled by default; you can enable this option in your"  >> ${erasedlist}
+                    echo  "          /etc/mailad/mailad.conf file setting the option"  >> ${erasedlist}
+                    echo  "          MAILDIRREMOVAL='yes', remember to make a 'make force-provision'"  >> ${erasedlist}
+                    echo  "          in your mailad local repo folder to apply the change."  >> ${erasedlist}
+                    echo  " " >> ${erasedlist}
+                else
+                    # delete it for good
+                    rm -rdf "${maildir}"
+                fi
             else
                 # warn
                 printf "%s months/(%s days)\t%s\t%s\n" "${months}" "${days}" "${size}" "${maildir}" >> ${warnlist}


### PR DESCRIPTION
If you have a old mail storage with ancient maildirs you can lose them, so this feature is made optional and disabled by default.

You as sysadmin needs to enable it on the config file. 