### PR TITLE
Switch from ping to nc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-09-23
+
+- Changed: Some users reported that we use ping to test for the AD-DC and in his envs there is no ping between it's networks, and that makes sense, we switched to test for the specific LDAP port connectivity instead pings (thanks Danny Paula for the tip)
+
 ## 2020-09-22
 
 - Fixed: ClamaV update repository configuration was not right (via freshclam.conf), fixed now: it includes multiple custom mirrors and improve timeouts for slow networks, and some other validations.

--- a/scripts/test_localhost.sh
+++ b/scripts/test_localhost.sh
@@ -58,17 +58,30 @@ else
     exit 1
 fi
 
-# ping the hostad
-ping -c 3 "$HOSTAD"
+# No ping, some users have VLANs with no ping allowed, we switch to nc to test if
+# the port is open, but we need to know the correct por if LDAP or LDAPS
+PORT=""
+if [ "$SECURELDAP" == "" -o "$SECURELDAP" == "no" -o "$SECURELDAP" == "No" ] ; then
+    # no sec, plain ldap
+    PORT=398
+else
+    # secure ldap
+    PORT=636
+fi
+
+# command
+nc "$HOSTAD" "$PORT" -vz  2> /dev/null
+
+# testing
 R=$?
 if [ $R -eq 0 ] ; then
-    echo "===> The domain host listed in HOSTAD is network reacheable!"
+    echo "===> We can reach the domain server listed in the configs!"
 else
     # fail
     echo "================================================================================="
     echo "ERROR!"
-    echo "    Domain host seems to be down or not reacheable!"
-    echo "    Check your network settings and cable"
+    echo "    We can't connect to the port $PORT of the AD server ($HOSTAD) specified in"
+    echo "    the config, check your network settings, firewalls, etc"
     echo "================================================================================="
     echo " "
 

--- a/scripts/test_localhost.sh
+++ b/scripts/test_localhost.sh
@@ -63,7 +63,7 @@ fi
 PORT=""
 if [ "$SECURELDAP" == "" -o "$SECURELDAP" == "no" -o "$SECURELDAP" == "No" ] ; then
     # no sec, plain ldap
-    PORT=398
+    PORT=389
 else
     # secure ldap
     PORT=636


### PR DESCRIPTION
Some users have firewalls between the mailserver and DC, and ping is not allowed, we switched to nc -vz to check for opened ports instead of pings