### PR TITLE
Fix the problem with the spaces in the full DNs names and other related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Dates must be YEAR-MONTH-DAY
 
 ## 2020-09-30
 
-- Fixed: Bug detected, The disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
-- Fixed: Bug detected, Altermime was not installed and the mail queue fails, added the install step (this is from the last feature or PR...)
+- Fixed: Bug detected, the disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
+- Fixed: Bug detected, altermime was not installed and the mail queue fails, added the install step (this is from the last feature or PR...)
 - Fixed: Bug detected, when you use OUs with spaces in the name the alias list via AD groups failed as the parsing failed, fixed.
 - Fixed: Bug detected, the emails sent via submission was not expanding the virtual_alias_maps, fixed. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Dates must be YEAR-MONTH-DAY
 
 ## 2020-09-30
 
-- Fixed: The disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
-- Fixed: Altermime was not installed and the mail queue fails, added the install step
+- Fixed: Bug detected, The disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
+- Fixed: Bug detected, Altermime was not installed and the mail queue fails, added the install step (this is from the last feature or PR...)
 - Fixed: Bug detected, when you use OUs with spaces in the name the alias list via AD groups failed as the parsing failed, fixed.
 - Fixed: Bug detected, the emails sent via submission was not expanding the virtual_alias_maps, fixed. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-09-30
+
+- Fixed: The disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
+- Fixed: Bug detected, when you use OUs with spaces in the name the alias list via AD groups failed as the parsing failed, fixed.
+
 ## 2020-09-26
 
 - Changed: We modified almost all bash script extensively: unifying functions on the common.conf file, that allow us to clean the scripts and improve the overall maintenance of the code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Dates must be YEAR-MONTH-DAY
 ## 2020-09-30
 
 - Fixed: The disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
+- Fixed: Altermime was not installed and the mail queue fails, added the install step
 - Fixed: Bug detected, when you use OUs with spaces in the name the alias list via AD groups failed as the parsing failed, fixed.
 
 ## 2020-09-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Dates must be YEAR-MONTH-DAY
 - Fixed: The disclaimer feature had a problem in one script with an incomplete sed statement, fixed.
 - Fixed: Altermime was not installed and the mail queue fails, added the install step
 - Fixed: Bug detected, when you use OUs with spaces in the name the alias list via AD groups failed as the parsing failed, fixed.
+- Fixed: Bug detected, the emails sent via submission was not expanding the virtual_alias_maps, fixed. 
 
 ## 2020-09-26
 

--- a/scripts/groups.sh
+++ b/scripts/groups.sh
@@ -55,27 +55,27 @@ fi
 TEMP=`mktemp`
 ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=group)(mail=*))" dn | grep "^dn:" > $TEMP
 
-RESULT=""
+declare -a RES
 # parsing the group names, as it can be coded in base64 when non default charset is used
 while IFS= read -r line ; do
     L=`echo $line | grep '::'`
     if [ -z "$L" ] ; then
-        R=`echo $line | awk '{print $2}'`
+        R=`echo $line | cut -d " " -f 2- `
     else
-        R=`echo $line | awk '{print $2}' | base64 -d`
+        R=`echo $line | cut -d " " -f 2-  | base64 -d`
     fi
 
     # aggregate
-    RESULT="$R $RESULT"
+    RES+=("$R")
 done < $TEMP
 
 rm $TEMP
 
-for G in `echo $RESULT | xargs `; do
+for G in "${RES[@]}"; do
     # search the group dn
     GEM=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=group)(distinguishedName=$G))" mail | grep "mail: " | awk '{print $2}'`
 
-    if [ "$GEM" != "" ] ; then
+    if [ "$GEM" ] ; then
         RESULT=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectCategory=person)(objectClass=user)(sAMAccountName=*)(memberOf=$G))" mail | grep "mail: " | awk '{print$2}' | tr '\n' ','`
 
         echo "# Group: $G" >> /etc/postfix/aliases/auto_aliases
@@ -88,11 +88,11 @@ done
 cd /etc/postfix/aliases && postmap auto_aliases
 postfix reload
 
-# check for the sysadmin group alias
-if [ "$SYSADMINS" != "" ] ; then
+# check foir the sysadmin group alias if set
+if [ "$SYSADMINS" ] ; then
     # search for it on the aliases files
     R=`cat /etc/postfix/aliases/auto_aliases /etc/postfix/aliases/alias_virtuales | awk '{print $1}' | grep "$SYSADMINS"`
-    if [ "$R" == "" ] ; then
+    if [ -z "$R" ] ; then
         # notice
         echo "===> Warning: SYSADMIN group not configured, check your mail for details!"
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -354,7 +354,10 @@ fi
 ### altermime
 if [ "$ENABLE_DISCLAIMER" == "yes" -o "$ENABLE_DISCLAIMER" == "Yes" ] ; then
     # enable disclaimer
-    echo "===> Disclaimer enabled on config, activating..."
+    echo "===> Disclaimer enabled on config, installing altermime..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get install $DEBIAN_DISCLAIMER_PKGS -y
 
     # notice
     echo "===> Enabling Altermime tweaks for disclaimer addition"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -388,7 +388,7 @@ else
     echo "===> Disclaimer disabled on config, disabling"
     
     # disable the dfilt line in the master.cf file on postfix
-    sed -i s/"content_filter=dfilt:"/"content_filter="
+    sed -i s/"content_filter=dfilt:"/"content_filter="/g /etc/postfix/master.cf
 fi
 
 # start services

--- a/var/postfix/master.cf
+++ b/var/postfix/master.cf
@@ -16,6 +16,7 @@ smtp      inet  n       -       y       -       -       smtpd
 #tlsproxy  unix  -       -       y       -       0       tlsproxy
 submission inet n       -       y       -       -       smtpd
   -o content_filter=dfilt:
+  -o receive_override_options=
   -o syslog_name=postfix/submission
   -o smtpd_tls_security_level=encrypt
   -o smtpd_sasl_auth_enable=yes


### PR DESCRIPTION
If the full LDAP DN name of the group had spaces it will fail to retrieve the emails from the users.

Two major problems: 

- We was looking for the second column, now we seek from the second to end
- We was handling the DNs as simple text delimited by spaces, now it's an array
