### PR TITLE
Dovecot auth cache ttl to big & size to small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-10-08
+
+- Added: More spanish translations (tks to @glpzzz) and link them to the original files.
+- Added: Include more contributors @glpzzz and @oneohthree
+- Modified: Improved the README with more eye-candy badges and the asciinema recording
+- Modified: Improve the contributions sections, adding more explicit funding instructions, adding a QR code for Transfermovil (Cuba only)
+
 ## 2020-10-07
 
 - Added: Spanish and German translations of he README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-10-09
+
+- Added: Fix to issue #107: small enterprise dovecot cache ttl to big, lower the ttl (from 1 hour to 10 minutes) and incremented the size of the cache for big enterprises (from ~5 to ~50 latest hits on cache)
+
 ## 2020-10-08
 
 - Added: More spanish translations (tks to @glpzzz) and link them to the original files.

--- a/var/dovecot-2.2/conf.d/10-auth.conf
+++ b/var/dovecot-2.2/conf.d/10-auth.conf
@@ -11,14 +11,14 @@ disable_plaintext_auth = no
 
 # Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
 # bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.
-auth_cache_size = 1M
+auth_cache_size = 10M
 
 # Time to live for cached data. After TTL expires the cached record is no
 # longer used, *except* if the main database lookup returns internal failure.
 # We also try to handle password changes automatically: If user's previous
 # authentication was successful, but this one wasn't, the cache isn't used.
 # For now this works only with plaintext authentication.
-auth_cache_ttl = 1 hour
+auth_cache_ttl = 10 minutes
 
 # TTL for negative hits (user not found, password mismatch).
 # 0 disables caching them completely.
@@ -39,7 +39,7 @@ auth_cache_negative_ttl = 1 hour
 # an extra check to make sure user can't exploit any potential quote escaping
 # vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
 # set this value to empty.
-#auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
+auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
 
 # Username character translations before it's looked up from databases. The
 # value contains series of from -> to characters. For example "#@/@" means

--- a/var/dovecot-2.3/conf.d/10-auth.conf
+++ b/var/dovecot-2.3/conf.d/10-auth.conf
@@ -18,7 +18,7 @@ auth_cache_size = 10M
 # We also try to handle password changes automatically: If user's previous
 # authentication was successful, but this one wasn't, the cache isn't used.
 # For now this works only with plaintext authentication.
-auth_cache_ttl = 1 minutes
+auth_cache_ttl = 10 minutes
 
 # TTL for negative hits (user not found, password mismatch).
 # 0 disables caching them completely.

--- a/var/dovecot-2.3/conf.d/10-auth.conf
+++ b/var/dovecot-2.3/conf.d/10-auth.conf
@@ -11,14 +11,14 @@ disable_plaintext_auth = no
 
 # Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
 # bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.
-auth_cache_size = 1M
+auth_cache_size = 10M
 
 # Time to live for cached data. After TTL expires the cached record is no
 # longer used, *except* if the main database lookup returns internal failure.
 # We also try to handle password changes automatically: If user's previous
 # authentication was successful, but this one wasn't, the cache isn't used.
 # For now this works only with plaintext authentication.
-auth_cache_ttl = 1 hour
+auth_cache_ttl = 1 minutes
 
 # TTL for negative hits (user not found, password mismatch).
 # 0 disables caching them completely.
@@ -39,7 +39,7 @@ auth_cache_negative_ttl = 1 hour
 # an extra check to make sure user can't exploit any potential quote escaping
 # vulnerabilities with SQL/LDAP databases. If you want to allow all characters,
 # set this value to empty.
-#auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
+auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
 
 # Username character translations before it's looked up from databases. The
 # value contains series of from -> to characters. For example "#@/@" means


### PR DESCRIPTION
For a small number of concurrent users the default ttl of the cache is to big, then if you lower it the cache size is to small.

We are lowering the ttl from 1 hour to 10 minutes (/6) and increasing the size from 1M to 10M (*10) this will help with small & large organizations