### PR TITLE
Stdev pavelmc t113 relay custom port remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Dates must be YEAR-MONTH-DAY
 ## 2020-10-13
 
 - Modified: Removed the SSLv2 in the listing of forbidden protocols (even disabled) in dovecot 2.2, it's not supported in SSL library so no reason to be here. 
+- Modified: Improved the parsing of the RELAY variable, to remove the ending ':port' part and the surrounding '[]' if present.
 
 ## 2020-10-12
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -71,7 +71,9 @@ LDAPURI=`get_ldap_uri`
 
 # add the mail gateway as a trusted source, aka the mynetworks
 if [ ! -z "$RELAY" ] ; then
-    MYNETWORK="$MYNETWORK $RELAY"
+    # must remove the port and any other char like '[]' we ofter use to avoid lookups
+    T=`echo $RELAY | cut -d ":" -f 1 | tr -d "[" | tr -d "]"`
+    MYNETWORK="$MYNETWORK $T"
 fi
 
 # add the LDAPURI & ESC_SYSADMINS to the vars


### PR DESCRIPTION
Improve the parsing of the RELAY before adding it to the MYNETWORKS var, removing the ":port" part and surrounding  "[]"