### PR TITLE
ldapsearch was truncating the output of long group names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-10-14
+
+- Fixed: AD groups with long names was not getting parsed on the automatic alias because ldapsearch tool was wrapping the output at 79 chars by default, added a fix to solve that; fixed.  
+
 ## 2020-10-13
 
 - Modified: Removed the SSLv2 in the listing of forbidden protocols (even disabled) in dovecot 2.2, it's not supported in SSL library so no reason to be here. 

--- a/scripts/check_maildirs.sh
+++ b/scripts/check_maildirs.sh
@@ -32,7 +32,7 @@ function isthere () {
     # return empty string or num of entries fount
 
     # LDAP query
-    RESULT=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=person)(wWWHomePage=${1}))" | grep "numEntries: " | awk '{print $3}'`
+    RESULT=`ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=person)(wWWHomePage=${1}))" | grep "numEntries: " | awk '{print $3}'`
 
     echo $RESULT
 }

--- a/scripts/groups.sh
+++ b/scripts/groups.sh
@@ -36,7 +36,7 @@ else
     echo "===> login into $HOSTAD as $LDAPBINDUSER"
 
     # LDAP query
-    RESULT=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectCategory=person)(objectClass=user)(sAMAccountName=*))" mail | grep "mail: " | grep "@$DOMAIN" | awk '{print $2}' | tr '\n' ','`
+    RESULT=`ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectCategory=person)(objectClass=user)(sAMAccountName=*))" mail | grep "mail: " | grep "@$DOMAIN" | awk '{print $2}' | tr '\n' ','`
 
     if [ "$RESULT" == "" ] ; then
         # empy result: Fail
@@ -53,7 +53,7 @@ fi
 
 # Getting the list of the groups in the search base
 TEMP=`mktemp`
-ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=group)(mail=*))" dn | grep "^dn:" > $TEMP
+ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=group)(mail=*))" dn | grep "^dn:" > $TEMP
 
 declare -a RES
 # parsing the group names, as it can be coded in base64 when non default charset is used
@@ -73,10 +73,10 @@ rm $TEMP
 
 for G in "${RES[@]}"; do
     # search the group dn
-    GEM=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=group)(distinguishedName=$G))" mail | grep "mail: " | awk '{print $2}'`
+    GEM=`ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=group)(distinguishedName=$G))" mail | grep "mail: " | awk '{print $2}'`
 
     if [ "$GEM" ] ; then
-        RESULT=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectCategory=person)(objectClass=user)(sAMAccountName=*)(memberOf=$G))" mail | grep "mail: " | awk '{print$2}' | tr '\n' ','`
+        RESULT=`ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectCategory=person)(objectClass=user)(sAMAccountName=*)(memberOf=$G))" mail | grep "mail: " | awk '{print$2}' | tr '\n' ','`
 
         echo "# Group: $G" >> /etc/postfix/aliases/auto_aliases
         echo "$GEM   $RESULT" >> /etc/postfix/aliases/auto_aliases

--- a/scripts/test_bind_dn.sh
+++ b/scripts/test_bind_dn.sh
@@ -55,7 +55,7 @@ else
 fi
 
 # LDAP query
-RESULT=`ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" | grep "numResponses"`
+RESULT=`ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" | grep "numResponses"`
 
 if [ "$RESULT" == "" ] ; then
     # empy result: Fail

--- a/scripts/test_mailadmin.sh
+++ b/scripts/test_mailadmin.sh
@@ -23,7 +23,7 @@ LDAPURI=`get_ldap_uri`
 echo "===> Searching for the user that owns the email: $ADMINMAIL"
 
 TEMP=`mktemp`
-ldapsearch -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=person)(mail=$ADMINMAIL))" > $TEMP
+ldapsearch -o ldif-wrap=no -H "$LDAPURI" -D "$LDAPBINDUSER" -w "$LDAPBINDPASSWD" -b "$LDAPSEARCHBASE" "(&(objectClass=person)(mail=$ADMINMAIL))" > $TEMP
 RESULTS=`cat $TEMP | grep "numEntries: " | awk '{print $3}'`
 
 if [ -z "$RESULTS" ] ; then


### PR DESCRIPTION
Just tell ldapsearch to not word wrap the output.