### PR TITLE
ClamAV freshclam updates fail via proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Dates must be YEAR-MONTH-DAY
 
 ## 2020-10-14
 
-- Fixed: AD groups with long names was not getting parsed on the automatic alias because ldapsearch tool was wrapping the output at 79 chars by default, added a fix to solve that; fixed.  
+- Fixed: AD groups with long names was not getting parsed on the automatic alias because ldapsearch tool was wrapping the output at 79 chars by default, added a fix to solve that; fixed.
+- Fixed: Updates form ClamAV failed when using proxy, it was the http/s prefix, must be omitted when using proxy, fixed 
 
 ## 2020-10-13
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -248,7 +248,16 @@ else
 
             # dump the config
             for M in `echo "${AV_ALT_MIRRORS}" | xargs` ;  do
-                echo "DatabaseMirror ${M}" >> $FILE
+                # if a proxy is set remove the 'http://' and 'https://' from the variables
+
+                if [ ! -z "$PROXY_HOST" -a ! -z "$PROXY_PORT" ] ; then
+                    # there is a proxy, remove the prefix
+                    Mm=`echo ${M} | sed s/'http:\/\/'//g | sed s/'https:\/\/'//g`
+                    echo "DatabaseMirror ${Mm}" >> $FILE
+                else
+                    # no proxy
+                    echo "DatabaseMirror ${M}" >> $FILE
+                fi
             done
         fi
     fi


### PR DESCRIPTION
Remove the http/https prefix from the address if on proxy