### PR TITLE
Fix the problem of ClamAV user add failing on Debian buster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2020-11-12
+
+- HAPPY BIRTHDAY #1 MailAD!!!
+- Fixed: A bug in the mail install script, the group tweaking for clamav was in place even if the user choose not to install an AV, fixed now.
+
 ## 2020-10-26
 
 - Fixed: The quota warnings emails (85 & 95% of the mailbox) was not being sent in Dovecot 2.3 (Ubuntu 20.04 & possibly also on Debian 10.x), was a permission problem on the script, fixed.

--- a/scripts/install_mail.sh
+++ b/scripts/install_mail.sh
@@ -36,10 +36,6 @@ if [ -f /etc/os-release ] ; then
 
             # Install
             install_debs
-
-            # Ad the clamav user to the amavis group, or it will not be able to reach emails to scan
-            echo "===> Setting correct Perms for clamav and amavis."
-            adduser clamav amavis
             ;;
         buster)
             # load the correct pkgs to be installed
@@ -50,10 +46,6 @@ if [ -f /etc/os-release ] ; then
 
             # Install
             install_debs
-
-            # Ad the clamav user to the amavis group, or it will not be able to reach emails to scan
-            echo "===> Setting correct Perms for clamav and amavis."
-            adduser clamav amavis
             ;;
         *)
             echo "==========================================================================="
@@ -65,4 +57,11 @@ if [ -f /etc/os-release ] ; then
             echo "==========================================================================="
             ;;
     esac
+
+    # fix permissions for clamav into amavis if AV is enabled
+    if [ "$ENABLE_AV" == "yes" -o "$ENABLE_AV" == "Yes" ] ; then
+        # Ad the clamav user to the amavis group, or it will not be able to reach emails to scan
+        echo "===> Setting correct Perms for clamav and amavis to work together"
+        adduser clamav amavis
+    fi
 fi


### PR DESCRIPTION
Add a test for this if the user asked for an AV.