### PR TITLE
Fix the LDAP URI handling on the groups.sh file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Dates must be YEAR-MONTH-DAY
 - Fixed: A bug (typo) on the 'make clean' command
 - Added: Checks for /sbin /usr/sbin missing on path on some debian systems
 - Changed: Improved the parsing of the LDAP bind testing
+- Fixed: Bug #158, groups.sh script was not updated with the new LDAP_URI autodetection of past improvements, sorry for that.
 
 ## 2022-02-24
 

--- a/common.conf
+++ b/common.conf
@@ -312,6 +312,7 @@ function disable_sa() {
 }
 
 # Get the ldap uri based on the file options
+# same function on scripts/groups.sh file
 function get_ldap_uri {
     # Import local settings
     source /etc/mailad/mailad.conf


### PR DESCRIPTION
Fix the groups.sh script to handle the automatic groups from AD groups, including the "everyone" group.