### PR TITLE
Debian 11 needs /etc/ldap/ldap.conf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2022-03-16
+
+- Fixed: Bug #168 Debian (et least on version 11) needs libldap and libldap-common as an explicit dependency
+
 ## 2022-03-09
 
 - Fixed: Bug #151 that was not completely fixed, now it's

--- a/common.conf
+++ b/common.conf
@@ -5,7 +5,7 @@
 # Do not change this unless you know what are you doing!!! 
 
 #### Pkgs to install for Debian 10.x "Buster"
-DEBIAN_BASE_PKGS="postfix postfix-pcre postfix-ldap dovecot-pop3d dovecot-imapd dovecot-ldap dovecot-sieve dovecot-managesieved libnet-ldap-perl ldap-utils rsync dnsutils pflogsumm mailutils amavisd-new p7zip-full unrar-free cabextract cron"
+DEBIAN_BASE_PKGS="postfix postfix-pcre postfix-ldap dovecot-pop3d dovecot-imapd dovecot-ldap dovecot-sieve dovecot-managesieved libnet-ldap-perl ldap-utils libldap libldap-common rsync dnsutils pflogsumm mailutils amavisd-new p7zip-full unrar-free cabextract cron"
 
 # Pkgs to install for Ubuntu Bionic & Focal (18.04/20.04)
 UBUNTU_BASE_PKGS="postfix postfix-pcre postfix-ldap dovecot-pop3d dovecot-imapd dovecot-ldap dovecot-sieve dovecot-managesieved libnet-ldap-perl ldap-utils rsync dnsutils pflogsumm mailutils amavisd-new-postfix p7zip-full p7zip-rar unrar-free cabextract"


### PR DESCRIPTION
and it's provided by libldap & libldap-common that are not installed when you install ldaputils