### PR TITLE
Stdev pavelmc t172 group fails debian no sbin in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is a note for developers about the recommended tags to keep track of the ch
 Dates must be YEAR-MONTH-DAY
 -->
 
+## 2022-03-25
+
+- Fixed: Bug #172, gropus update script fails under Debian as no sbin on path (postmap reside on sbin), silent fix added.
+
 ## 2022-03-23
 
 - Fixed: Bug #168 reopened, Debian 11 was picky with some ldap packages

--- a/scripts/groups.sh
+++ b/scripts/groups.sh
@@ -16,6 +16,14 @@
 # load conf files
 source /etc/mailad/mailad.conf
 
+# test /sbin on some envs (Debian 10/11)
+SBIN=`echo $PATH | grep "/sbin"`
+if [ -z "$SBIN" ] ; then
+    # export sbins silently
+    PATH="/sbin:/usr/sbin:$PATH"
+    export PATH
+fi
+
 # Get the ldap uri based on the file options
 # same function on common.conf file
 function get_ldap_uri {


### PR DESCRIPTION
Group.sh fails, postmap not foud as sbin not in PATH, again Debian... why!?